### PR TITLE
feat(slideshow): add pills pagination variant with custom styles and …

### DIFF
--- a/assets/component-slider.css
+++ b/assets/component-slider.css
@@ -247,6 +247,8 @@ slider-component.slider-component-full-width {
   display: flex;
   justify-content: center;
   min-width: 4.4rem;
+  color: rgb(var(--color-background));
+  background-color: transparent;
 }
 
 @media screen and (min-width: 750px) {
@@ -269,31 +271,31 @@ slider-component.slider-component-full-width {
   width: 2.3rem;
   height: 0.8rem;
   border-radius: 0.3rem;
-  border: 1px solid #a9d00c;
+  border: 1px solid rgb(var(--color-foreground));
   padding: 0;
-  /* margin: 0 4px; */
   display: block;
+  background: transparent;
 }
 
 .slider-counter__link--pills:hover .dot {
-  background-color: rgba(200, 245, 0, 0.5);
+  background-color: rgba(var(--color-background), 0.7);
 }
 
 .slider-counter__link--active.slider-counter__link--pills .dot {
-  background: rgba(200, 245, 0, 0.5);
+  background-color: rgb(var(--color-background));
 }
 
 .slider-counter__link--dots .dot {
   width: 1rem;
   height: 1rem;
   border-radius: 50%;
-  border: 0.1rem solid rgba(var(--color-foreground), 0.5);
+  border: 0.1rem solid rgba(var(--color-background), 0.5);
   padding: 0;
   display: block;
 }
 
 .slider-counter__link--active.slider-counter__link--dots .dot {
-  background-color: rgb(var(--color-foreground));
+  background-color: rgb(var(--color-background));
 }
 
 @media screen and (forced-colors: active) {
@@ -303,7 +305,7 @@ slider-component.slider-component-full-width {
 }
 
 .slider-counter__link--dots:not(.slider-counter__link--active):hover .dot {
-  border-color: rgb(var(--color-foreground));
+  border-color: rgb(var(--color-background));
 }
 
 .slider-counter__link--dots .dot,
@@ -318,17 +320,17 @@ slider-component.slider-component-full-width {
 }
 
 .slider-counter__link--numbers {
-  color: rgba(var(--color-foreground), 0.5);
+  color: rgba(var(--color-background), 0.5);
   text-decoration: none;
 }
 
 .slider-counter__link--numbers:hover {
-  color: rgb(var(--color-foreground));
+  color: rgb(var(--color-background), 0.8);
 }
 
 .slider-counter__link--active.slider-counter__link--numbers {
   text-decoration: underline;
-  color: rgb(var(--color-foreground));
+  color: rgb(var(--color-background), 1);
 }
 
 
@@ -358,7 +360,7 @@ slider-component.slider-component-full-width {
 }
 
 .slider-button {
-  color: rgba(var(--color-foreground), 0.75);
+  color: rgba(var(--color-background), 0.75);
   background: transparent;
   border: none;
   cursor: pointer;
@@ -370,7 +372,7 @@ slider-component.slider-component-full-width {
 }
 
 .slider-button:not([disabled]):hover {
-  color: rgb(var(--color-foreground));
+  color: rgb(var(--color-background));
 }
 
 .slider-button .icon {
@@ -378,7 +380,7 @@ slider-component.slider-component-full-width {
 }
 
 .slider-button[disabled] .icon {
-  color: rgba(var(--color-foreground), 0.3);
+  color: rgba(var(--color-background), 0.3);
   cursor: not-allowed;
 }
 
@@ -401,16 +403,18 @@ slider-component.slider-component-full-width {
 .slideshow__controls--pills .slider-button {
   width: 3.5rem;
   height: 1.5rem;
-  border: 1px solid #a9d00cca;
+  border: 1px solid rgb(var(--color-foreground));
   border-radius: 10px;
-  color: #c8f902;
   padding: 6px 14px;
   font-size: 18px;
   padding: 0.5rem;
+  color: rgb(var(--color-foreground));
+  background: transparent;
 }
 
-.slideshow__controls--pills .slider-button:hover {
-  background-color: rgba(200, 245, 0, 0.5);
+.slideshow__controls--pills .slider-button:not([disabled]):hover {
+  background: rgba(var(--color-background), 0.7);
+  color: rgb(var(--color-foreground));
 }
 
 .slideshow__controls--pills .slider-button .icon {

--- a/assets/custom-faq.css
+++ b/assets/custom-faq.css
@@ -1,0 +1,164 @@
+.faq__wrapper {
+    display: flex;
+    flex-direction: column;
+}
+
+.faq__wrapper.spacing--none {
+    padding: 0;
+    margin: 0;
+}
+
+.faq__wrapper.spacing--small {
+    padding-top: 20px;
+    margin-bottom: 20px;
+}
+
+.faq__wrapper.spacing--medium {
+    padding-top: 40px;
+    margin-bottom: 40px;
+}
+
+.faq__wrapper.spacing--large {
+    padding-top: 80px;
+    margin-bottom: 80px;
+}
+
+.faq__wrapper--left {
+    align-items: flex-start;
+}
+
+.faq__wrapper--left {
+    text-align: center;
+}
+
+.faq__wrapper--center {
+    align-items: center;
+    text-align: center;
+}
+
+.faq__wrapper--right {
+    align-items: flex-end;
+}
+
+.faq_title {
+    margin: 0 0 16px 0;
+    color: rgba(var(--color-foreground));
+    ;
+}
+
+.faq__description {
+    margin: 0 0 48px 0;
+}
+
+.dropdown-list {
+    padding: 0;
+    margin: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+    max-width: 800px;
+}
+
+@media screen and (max-width: 749px) {
+    .dropdown-list {
+        padding: 10px 20px;
+    }
+}
+
+.dropdown-list__item {
+    background-color: rgb(var(--color-button));
+    border: 1px solid rgb(var(--color-badge-border));
+    padding: 24px;
+    max-width: 880px;
+    border-radius: 8px;
+    text-align: left;
+}
+
+.dropdown-list__item--active .dropdown-list__content {
+    max-height: 500px;
+    opacity: 1;
+}
+
+.dropdown-list__item--active .dropdown-list__icon::before {
+    transform: translate(-50%, -50%) rotate(0deg)
+}
+
+
+.dropdown-list__item--active .dropdown-list__btn {
+    margin: 0 0 24px 0;
+
+}
+
+.dropdown-list__btn {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    background-color: transparent;
+    border: none;
+    cursor: pointer;
+    margin: 0;
+    transition: margin 0.3s ease;
+    padding: 0;
+    color: rgba(var(--color-foreground));
+    ;
+}
+
+.dropdown-list__btn:focus-visible,
+.dropdown-list__btn:hover {
+    outline: none;
+    color: rgba(var(--color-foreground), 0.5);
+}
+
+.dropdown-list__title {
+    margin: 0;
+}
+
+.dropdown-list__text {
+    max-width: 500px;
+}
+
+.dropdown-list__icon {
+    display: block;
+    position: relative;
+    width: 20px;
+    height: 20px;
+    border: 1px solid rgba(var(--color-foreground));
+    ;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.dropdown-list__icon::after,
+.dropdown-list__icon::before {
+    content: "";
+    display: block;
+    width: 10px;
+    height: 1px;
+    background-color: rgba(var(--color-foreground));
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.dropdown-list__icon::after {
+    transform: translate(-50%, -50%) rotate(0deg);
+}
+
+.dropdown-list__icon::before {
+    transform: translate(-50%, -50%) rotate(90deg)
+}
+
+
+.dropdown-list__content {
+    color: rgba(var(--color-button-text));
+    margin: 0;
+    max-height: 0;
+    transform-origin: top;
+    opacity: 0;
+    transition: transform 0.3s ease, opacity 0.3s ease 0.1s;
+}

--- a/assets/global.js
+++ b/assets/global.js
@@ -1363,3 +1363,31 @@ class CartPerformance {
     );
   }
 }
+
+class FAQComponent extends HTMLElement {
+  constructor() {
+    super();
+    this.init();
+  }
+
+  init() {
+    this.querySelectorAll('.dropdown-list__btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const item = btn.closest('.dropdown-list__item');
+        const isActive = item.classList.contains('dropdown-list__item--active');
+
+        // Закрыть все
+        this.querySelectorAll('.dropdown-list__item').forEach((el) =>
+          el.classList.remove('dropdown-list__item--active')
+        );
+
+        // Открытие по клику
+        if (!isActive) {
+          item.classList.add('dropdown-list__item--active');
+        }
+      });
+    });
+  }
+}
+
+customElements.define('faq-component', FAQComponent);

--- a/assets/icon-caret.svg
+++ b/assets/icon-caret.svg
@@ -1,1 +1,5 @@
-<svg class="icon icon-caret" viewBox="0 0 10 6"><path fill="currentColor" fill-rule="evenodd" d="M9.354.646a.5.5 0 0 0-.708 0L5 4.293 1.354.646a.5.5 0 0 0-.708.708l4 4a.5.5 0 0 0 .708 0l4-4a.5.5 0 0 0 0-.708" clip-rule="evenodd"/></svg>
+<svg class="icon icon-caret" viewBox="0 0 10 6">
+    <path fill="currentColor" fill-rule="evenodd"
+        d="M9.354.646a.5.5 0 0 0-.708 0L5 4.293 1.354.646a.5.5 0 0 0-.708.708l4 4a.5.5 0 0 0 .708 0l4-4a.5.5 0 0 0 0-.708"
+        clip-rule="evenodd" />
+</svg>

--- a/sections/custom-faq.liquid
+++ b/sections/custom-faq.liquid
@@ -1,0 +1,103 @@
+{{ 'custom-faq.css' | asset_url | stylesheet_tag }}
+
+<faq-component class="faq" id="faq-{{ section.id }}">
+  <div class="faq__wrapper faq__wrapper--{{ section.settings.content_alignment }} color-{{ section.settings.color_scheme }} spacing--{{ section.settings.padding_size }}">
+    {% if section.settings.heading != blank %}
+      <h2 class="faq__title">{{ section.settings.heading }}</h2>
+    {% endif %}
+    {% if section.settings.subheading != blank %}
+      <p class="faq__description">{{ section.settings.subheading }}</p>
+    {% endif %}
+
+    <ul class="dropdown-list">
+      {% for block in section.blocks %}
+        <li class="dropdown-list__item">
+          <h3 class="dropdown-list__title">
+            <button class="dropdown-list__btn" type="button" aria-label="Toggle answer">
+              <span class="dropdown-list__text">{{ block.settings.question }}</span>
+              <span class="dropdown-list__icon"></span>
+            </button>
+          </h3>
+          <p class="dropdown-list__content">
+            {{ block.settings.answer }}
+          </p>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</faq-component>
+
+{% schema %}
+{
+  "name": "FAQ",
+  "settings": [
+    {
+      "type": "text",
+      "id": "heading",
+      "label": "Title",
+      "default": "Frequently asked questions"
+    },
+    {
+      "type": "text",
+      "id": "subheading",
+      "label": "Description",
+      "default": "Answers to frequently asked questions ."
+    },
+    {
+      "type": "select",
+      "id": "content_alignment",
+      "label": "Aligning content",
+      "default": "center",
+      "options": [
+        { "value": "left", "label": "Left" },
+        { "value": "center", "label": "Center" },
+        { "value": "right", "label": "Right" }
+      ]
+    },
+    {
+      "type": "select",
+      "id": "padding_size",
+      "label": "Section indents",
+      "options": [
+        { "value": "none", "label": "Without indents" },
+        { "value": "small", "label": "Small" },
+        { "value": "medium", "label": "Average" },
+        { "value": "large", "label": "Large" }
+      ],
+      "default": "medium"
+    },
+    {
+      "type": "color_scheme",
+      "id": "color_scheme",
+      "label": "Color scheme",
+      "default": "background-1"
+    }
+  ],
+  "blocks": [
+    {
+      "type": "faq_item",
+      "name": "FAQ Item",
+      "settings": [
+        {
+          "type": "text",
+          "id": "question",
+          "label": "Question",
+          "default": "Your question here"
+        },
+        {
+          "type": "textarea",
+          "id": "answer",
+          "label": "Answer",
+          "default": "Your answer here"
+        }
+      ]
+    }
+  ],
+  "presets": [
+    {
+      "name": "FAQ",
+      "category": "Custom"
+    }
+  ]
+}
+{% endschema %}

--- a/sections/slideshow.liquid
+++ b/sections/slideshow.liquid
@@ -36,7 +36,7 @@
       {%- if section.settings.slider_visual != 'pills' -%}
         <button
           type="button"
-          class="slider-button slider-button--prev"
+          class="slider-button slider-button--prev color-{{ section.settings.pagination_color_scheme }}"
           name="previous"
           aria-label="{{ 'sections.slideshow.previous_slideshow' | t }}"
           aria-controls="Slider-{{ section.id }}"
@@ -46,7 +46,7 @@
           </span>
         </button>
       {%- endif -%}
-      <div class="slider-counter slider-counter--{{ section.settings.slider_visual }}{% if section.settings.slider_visual == 'counter' or section.settings.slider_visual == 'numbers' %} caption{% endif %}">
+      <div class="slider-counter slider-counter--{{ section.settings.slider_visual }}{% if section.settings.slider_visual == 'counter' or section.settings.slider_visual == 'numbers' %} caption{% endif %} color-{{ section.settings.pagination_color_scheme }}">
         {%- if section.settings.slider_visual == 'counter' -%}
           <span class="slider-counter--current">1</span>
           <span aria-hidden="true"> / </span>
@@ -60,7 +60,7 @@
                 aria-label="{{ 'sections.slideshow.load_slide' | t }} {{ forloop.index }} {{ 'general.slider.of' | t }} {{ forloop.length }}"
                 aria-controls="Slider-{{ section.id }}"
               >
-                <span class="dot"></span>
+                <span class="dot color-{{ section.settings.pagination_color_scheme }}"></span>
               </button>
             {%- endfor -%}
           </div>
@@ -68,7 +68,7 @@
           <div class="slideshow__control-wrapper">
             {%- for block in section.blocks -%}
               <button
-                class="slider-counter__link slider-counter__link--{{ section.settings.slider_visual }} link"
+                class="slider-counter__link slider-counter__link--{{ section.settings.slider_visual }} link color-{{ section.settings.pagination_color_scheme }}"
                 aria-label="{{ 'sections.slideshow.load_slide' | t }} {{ forloop.index }} {{ 'general.slider.of' | t }} {{ forloop.length }}"
                 aria-controls="Slider-{{ section.id }}"
               >
@@ -85,7 +85,7 @@
       {%- if section.settings.slider_visual != 'pills' -%}
         <button
           type="button"
-          class="slider-button slider-button--next"
+          class="slider-button slider-button--next color-{{ section.settings.pagination_color_scheme }}"
           name="next"
           aria-label="{{ 'sections.slideshow.next_slideshow' | t }}"
           aria-controls="Slider-{{ section.id }}"
@@ -222,7 +222,7 @@
     <div class="slideshow__controls slider-buttons{% if section.settings.show_text_below %} slideshow__controls--border-radius-mobile{% endif %}{% if section.settings.slider_visual == 'pills' %} slideshow__controls--pills{% endif %}">
       <button
         type="button"
-        class="slider-button slider-button--prev"
+        class="slider-button slider-button--prev color-{{ section.settings.pagination_color_scheme }}"
         name="previous"
         aria-label="{{ 'sections.slideshow.previous_slideshow' | t }}"
         aria-controls="Slider-{{ section.id }}"
@@ -231,7 +231,7 @@
           {{- 'icon-caret.svg' | inline_asset_content -}}
         </span>
       </button>
-      <div class="slider-counter slider-counter--{{ section.settings.slider_visual }}{% if section.settings.slider_visual == 'counter' or section.settings.slider_visual == 'numbers' %} caption{% endif %}">
+      <div class="slider-counter slider-counter--{{ section.settings.slider_visual }}{% if section.settings.slider_visual == 'counter' or section.settings.slider_visual == 'numbers' %} caption{% endif %} color-{{ section.settings.pagination_color_scheme }}">
         {%- if section.settings.slider_visual == 'counter' -%}
           <span class="slider-counter--current">1</span>
           <span aria-hidden="true"> / </span>
@@ -241,11 +241,11 @@
           <div class="slideshow__control-wrapper">
             {%- for block in section.blocks -%}
               <button
-                class="slider-counter__link slider-counter__link--{{ section.settings.slider_visual }} link"
+                class="slider-counter__link slider-counter__link--{{ section.settings.slider_visual }} link color-{{ section.settings.pagination_color_scheme }}"
                 aria-label="{{ 'sections.slideshow.load_slide' | t }} {{ forloop.index }} {{ 'general.slider.of' | t }} {{ forloop.length }}"
                 aria-controls="Slider-{{ section.id }}"
               >
-                <span class="dot"></span>
+                <span class="dot color-{{ section.settings.pagination_color_scheme }}"></span>
               </button>
             {%- endfor -%}
           </div>
@@ -253,7 +253,7 @@
           <div class="slideshow__control-wrapper">
             {%- for block in section.blocks -%}
               <button
-                class="slider-counter__link slider-counter__link--{{ section.settings.slider_visual }} link"
+                class="slider-counter__link slider-counter__link--{{ section.settings.slider_visual }} link color-{{ section.settings.pagination_color_scheme }}"
                 aria-label="{{ 'sections.slideshow.load_slide' | t }} {{ forloop.index }} {{ 'general.slider.of' | t }} {{ forloop.length }}"
                 aria-controls="Slider-{{ section.id }}"
               >
@@ -269,7 +269,7 @@
       </div>
       <button
         type="button"
-        class="slider-button slider-button--next"
+        class="slider-button slider-button--next color-{{ section.settings.pagination_color_scheme }}"
         name="next"
         aria-label="{{ 'sections.slideshow.next_slideshow' | t }}"
         aria-controls="Slider-{{ section.id }}"
@@ -358,6 +358,12 @@
       ],
       "default": "counter",
       "label": "t:sections.slideshow.settings.slider_visual.label"
+    },
+    {
+      "type": "color_scheme",
+      "id": "pagination_color_scheme",
+      "label": "Pagination color scheme",
+      "default": "scheme-1"
     },
     {
       "type": "checkbox",


### PR DESCRIPTION
Опис завдання

Створити Dev-store у Partner Dashboard.
Встановити тему Dawn.
Завантажити тему через CLI:  shopify theme pull
Створити репозиторій shopify-<назва-стору> на GitHub.
Завантажити код у GitHub.
Створити гілку dev від main.
Прив’язати обидві теми до GitHub у Shopify Admin (main/dev).
Створити feature-гілку, змінити секцію, зробити commit.
Відкрити PR → merge у dev.

Реалізувати новий тип пагінації для слайдера — pills.
Потрібно було додати кастомний вибір пагинації через адмінку не тільки через стандартні dots / numbers / counter, а й через кастомні “пігулки” (pills).

Реалізований функціонал

Встановлена тема Dawn в тестовому магазині.
Завантажена тема локально через CLI
Створенно репозиторій shopify-ferher-my на GitHub
Завантаженно код у GitHub
Створенно гілку dev від main
Привязав обидві теми до GitHub у Shopify Admin (main/dev)
Створена гілка feature, внесені зміни в секцію SlidShow, зробленний commit згідно Conventional Commits
Відкрито PR → merge у dev.

Додано новий тип pills у налаштуваннях слайдера
Реалізовано рендер кнопок у вигляді pills у Liquid-шаблоні
Додано логіку активного стану (--active) для pills
Налаштовано перемикання слайдів по кліку на pills
Підтримка автопрокрутки для pills
Окремі стилі в CSS (.slider-counter__link--pills)
Адаптація кнопок “prev/next” під pills тему

Технології та підходи
Git
Shopify Liquid 
Vanilla JavaScript для логіки слайдера
CSS 
Використання існуючої архітектури слайдера (адаптовано під pills без переписування основи)

Примітки
Найбільша складність була у тому, щоб pills коректно працювали з уже написаною логікою (активний клас, автоплей).
Виникали баги з undefined при відсутності autoplay-кнопок — додано перевірки в JS.
Для кольорових схем поки використовується стандартний підхід.

 Пов’язані ресурси
https://www.conventionalcommits.org/en/v1.0.0/
https://shopify.dev/docs/api/shopify-cli