### PR TITLE
feat(product-banner): implement base structure with color & size opti…

### DIFF
--- a/assets/custom-product-detail.css
+++ b/assets/custom-product-detail.css
@@ -1,0 +1,150 @@
+.product-detail__wrapper {
+    display: grid;
+    grid-template-columns: 648px auto;
+    gap: 60px;
+}
+
+.product-detail__inner-left {
+    display: flex;
+    flex-direction: row-reverse;
+    gap: 24px;
+    max-height: 536px;
+}
+
+.product-detail__wrapper-big-img {
+    position: relative;
+    aspect-ratio: 1 / 1;
+    max-width: 100%;
+    height: auto;
+}
+
+.product-detail__wrapper-big-img img {
+    height: 100%;
+}
+
+.product-detail__image--big {
+    width: 100%;
+    height: 100%;
+    border-radius: 8px;
+    overflow: hidden;
+    cursor: auto;
+}
+
+.product-detail__title {
+    margin: 0 0 12px 0;
+}
+
+.product-detail__price {
+    display: block;
+    margin: 0 0 16px 0;
+    color: #777777;
+}
+
+.product-detail__option-color,
+.product-detail__option-size {
+    display: flex;
+    gap: 8px;
+    border: none;
+    padding: 0;
+    margin: 0 0 16px 0;
+}
+
+.product-detail__legend {
+    margin: 0 0 12px 0;
+}
+
+.product-detail__size-label-inner {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    width: 100%;
+}
+
+.product-detail__btn {
+    margin: 0 0 32px 0;
+    position: relative;
+}
+
+.product-detail__btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.product-detail__btn:disabled::after {
+    content: "Please select a size";
+    position: absolute;
+    top: -40px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #000000;
+    color: #ffffff;
+    padding: 6px 10px;
+    border-radius: 4px;
+    font-size: 12px;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.product-detail__btn:disabled:hover::after {
+    opacity: 1;
+}
+
+.product-detail__description {
+    margin: 0;
+    color: #777777;
+}
+
+.custom-radio {
+    cursor: pointer;
+}
+
+.custom-radio:focus-visible .custom-radio__visual,
+.custom-radio:hover .custom-radio__visual {
+    outline: none;
+    border: 1px solid #777777;
+}
+
+.custom-radio__visual {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-content: center;
+    border: 1px solid #cccccc;
+    border-radius: 8px;
+    padding: 16px;
+}
+
+.custom-radio__visual--img {
+    padding: 0;
+    width: 88px;
+    height: 88px;
+    border: 1px solid #000000;
+    border-color: transparent;
+}
+
+.custom-radio__field:checked+.custom-radio__visual {
+    border-color: #000000;
+}
+
+input[type="radio" i] {
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
+    pointer-events: none;
+}
+
+/* Пока так временно, позже планирую нормально переделать */
+
+.сolor-white { background-color: #ffffff; }
+.color-black { background-color: #000000; }
+.color-gray  { background-color: #777777; }
+.color-light-gray { background-color: #cccccc; }
+.color-red   { background-color: #ff0000; }
+.color-blue  { background-color: #3366ff; }
+.color-green { background-color: #28a745; }
+.color-yellow { background-color: #ffcc00; }
+.color-orange { background-color: #ff6600; }
+.color-purple { background-color: #800080; }

--- a/assets/custom-product-detail.css
+++ b/assets/custom-product-detail.css
@@ -2,6 +2,7 @@
     display: grid;
     grid-template-columns: 648px auto;
     gap: 60px;
+    padding: 20px;
 }
 
 .product-detail__inner-left {
@@ -16,6 +17,7 @@
     aspect-ratio: 1 / 1;
     max-width: 100%;
     height: auto;
+    max-height: 536px;
 }
 
 .product-detail__wrapper-big-img img {
@@ -91,6 +93,25 @@
     opacity: 1;
 }
 
+.product-detail__btn {
+    background-color: #000000;
+    color: #ffffff;
+    border: none;
+    padding: 16px;
+    width: 100%;
+    border-radius: 8px;
+}
+
+.product-detail__btn:hover {
+    background-color: #737373;
+    cursor: pointer;
+}
+
+.product-detail__btn:disabled {
+    background-color: #CACACB;
+    cursor: auto;
+}
+
 .product-detail__description {
     margin: 0;
     color: #777777;
@@ -98,12 +119,6 @@
 
 .custom-radio {
     cursor: pointer;
-}
-
-.custom-radio:focus-visible .custom-radio__visual,
-.custom-radio:hover .custom-radio__visual {
-    outline: none;
-    border: 1px solid #777777;
 }
 
 .custom-radio__visual {
@@ -116,16 +131,34 @@
     padding: 16px;
 }
 
+.custom-radio__field:focus-visible+.custom-radio__visual,
+.custom-radio__field:hover+.custom-radio__visual,
+.custom-radio__field:checked+.custom-radio__visual {
+    border-color: #000000;
+}
+
+.custom-radio__visual--color {
+    border-radius: 50%;
+    border: 2px solid #000000;
+}
+
+.custom-radio__field:focus-visible+.custom-radio__visual--color,
+.custom-radio__field:hover+.custom-radio__visual--color {
+    border-color: #777777;
+    opacity: 0.9;
+}
+
+.custom-radio__field:checked+.custom-radio__visual--color {
+    border-color: #777777;
+    opacity: 0.8;
+}
+
 .custom-radio__visual--img {
     padding: 0;
     width: 88px;
     height: 88px;
     border: 1px solid #000000;
     border-color: transparent;
-}
-
-.custom-radio__field:checked+.custom-radio__visual {
-    border-color: #000000;
 }
 
 input[type="radio" i] {
@@ -135,16 +168,3 @@ input[type="radio" i] {
     height: 0;
     pointer-events: none;
 }
-
-/* Пока так временно, позже планирую нормально переделать */
-
-.сolor-white { background-color: #ffffff; }
-.color-black { background-color: #000000; }
-.color-gray  { background-color: #777777; }
-.color-light-gray { background-color: #cccccc; }
-.color-red   { background-color: #ff0000; }
-.color-blue  { background-color: #3366ff; }
-.color-green { background-color: #28a745; }
-.color-yellow { background-color: #ffcc00; }
-.color-orange { background-color: #ff6600; }
-.color-purple { background-color: #800080; }

--- a/assets/custom-product-detail.css
+++ b/assets/custom-product-detail.css
@@ -1,8 +1,7 @@
 .product-detail__wrapper {
     display: grid;
-    grid-template-columns: 648px auto;
+    grid-template-columns: 1fr 1fr;
     gap: 60px;
-    padding: 20px;
 }
 
 .product-detail__inner-left {
@@ -18,19 +17,64 @@
     max-width: 100%;
     height: auto;
     max-height: 536px;
+    border-radius: 8px;
+    overflow: hidden;
+
 }
 
 .product-detail__wrapper-big-img img {
     height: 100%;
+    width: 100%;
+    object-fit: cover;
 }
 
-.product-detail__image--big {
+.product-detail__thumb-group {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 24px;
+}
+
+.product-detail__btn-img {
+    padding: 0;
+    width: 88px;
+    height: 88px;
+    background-color: transparent;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    overflow: hidden;
+    position: relative;
+    flex: 0 0 auto;
+}
+
+.product-detail__btn-img:focus-visible,
+.product-detail__btn-img:hover {
+    outline: none;
+    border: 1px solid gray;
+}
+
+.product-detail__btn-img::after {
+    display: block;
+    content: "";
     width: 100%;
     height: 100%;
-    border-radius: 8px;
-    overflow: hidden;
+    background-color: #000000;
+    position: absolute;
+    top: 0;
+    left: 0;
+    opacity: 0;
+}
+
+.product-detail__btn-img--active {
+    pointer-events: none;
     cursor: auto;
 }
+
+.product-detail__btn-img--active::after {
+    opacity: 0.2;
+}
+
 
 .product-detail__title {
     margin: 0 0 12px 0;
@@ -38,7 +82,7 @@
 
 .product-detail__price {
     display: block;
-    margin: 0 0 16px 0;
+    margin: 0 0 10px 0;
     color: #777777;
 }
 
@@ -51,13 +95,14 @@
     margin: 0 0 16px 0;
 }
 
-.product-detail__legend {
+.product-detail__legend,
+.product-detail__availability {
     margin: 0 0 12px 0;
 }
 
 .product-detail__size-label-inner {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
     gap: 8px;
     width: 100%;
 }
@@ -138,6 +183,8 @@
 }
 
 .custom-radio__visual--color {
+    width: 32px;
+    height: 32px;
     border-radius: 50%;
     border: 2px solid #000000;
 }
@@ -151,14 +198,6 @@
 .custom-radio__field:checked+.custom-radio__visual--color {
     border-color: #777777;
     opacity: 0.8;
-}
-
-.custom-radio__visual--img {
-    padding: 0;
-    width: 88px;
-    height: 88px;
-    border: 1px solid #000000;
-    border-color: transparent;
 }
 
 input[type="radio" i] {

--- a/assets/global.js
+++ b/assets/global.js
@@ -1367,15 +1367,17 @@ class CartPerformance {
 class ProductDetail {
   constructor(section) {
     this.section = section;
-
     this.colorInputs = this.section.querySelectorAll('input[name="color"]');
     this.sizeInputs = this.section.querySelectorAll('input[name="size"]');
     this.availabilityEl = this.section.querySelector('#variant-availability');
     this.addToCartBtn = this.section.querySelector('.product-detail__btn');
+    this.mainImageEl = this.section.querySelector('.product-detail__wrapper-big-img img');
 
-    // парсим варианты
-    const variantsEl = document.getElementById('product-variants');
-    this.variants = variantsEl ? JSON.parse(variantsEl.textContent) : [];
+    const productId = this.section.dataset.productId;
+
+    // парсинг JSON с вариантами и остатками
+    const inventoryDataEl = document.getElementById(`VariantInventory-${productId}`);
+    this.variants = inventoryDataEl ? JSON.parse(inventoryDataEl.textContent) : {};
 
     this.init();
   }
@@ -1384,42 +1386,79 @@ class ProductDetail {
     const selectedColor = this.section.querySelector('input[name="color"]:checked');
     const selectedSize = this.section.querySelector('input[name="size"]:checked');
 
-    // Собираю массив выбранных опций
-    const selectedOptions = [];
-    if (selectedSize) selectedOptions.push(selectedSize.value);
-    if (selectedColor) selectedOptions.push(selectedColor.value);
+    if (!selectedColor || !selectedSize) return;
 
-    // Ищу совпадения, заранее свел массивы к одному виду
-    const match = this.variants.find(v => {
+    // Сбор массива выбранных опций
+    const selectedOptions = [selectedSize.value, selectedColor.value].map(o => o.toLowerCase());
+
+    // Поиск вариантов у которых options совпадают с выбранными
+    const match = Object.values(this.variants).find(v => {
+      if (!v.options) return false;
       const variantOptions = v.options.map(o => o.toLowerCase());
-      const selected = selectedOptions.map(o => o.toLowerCase());
-
-      return JSON.stringify(variantOptions) === JSON.stringify(selected);
+      return selectedOptions.every(opt => variantOptions.includes(opt));
     });
 
-
     if (match) {
-      if (match.available) {
-        this.availabilityEl.textContent = `In stock`;
+      const quantity = match.inventory_quantity ?? 0;
+
+      if (match.available && quantity > 0) {
+        this.availabilityEl.textContent = `In stock: ${quantity}`;
+        this.addToCartBtn.disabled = false;
       } else {
         this.availabilityEl.textContent = 'Sold out';
+        this.addToCartBtn.disabled = true;
+      }
+    } else {
+      this.availabilityEl.textContent = 'Variant not found';
+      this.addToCartBtn.disabled = true;
+    }
+  }
+
+  updateMainImage(colorValue) {
+    // Поиск цвета
+    const match = Object.values(this.variants).find(v => {
+      if (!v.options) return false;
+      return v.options.some(o => o.toLowerCase() === colorValue.toLowerCase());
+    });
+
+    // Замена картинки
+      const imageUrl = match.featured_image.startsWith('//')
+        ? `https:${match.featured_image}`
+        : match.featured_image;
+
+      if (this.mainImageEl) {
+        this.mainImageEl.src = imageUrl;
+        this.mainImageEl.srcset = ''; // сброс srcset
+        this.mainImageEl.alt = match.name || 'Product image';
       }
     }
   }
 
   init() {
+    // Слушатели для радио кнопок, изменения состояний по клику
+    [...this.colorInputs, ...this.sizeInputs].forEach(input => {
+      input.addEventListener('change', () => this.updateVariant());
+    });
+
     this.colorInputs.forEach(input => {
-      input.addEventListener('change', () => this.updateVariant());
+      input.addEventListener('change', (e) => {
+        const colorValue = e.target.value;
+        this.updateMainImage(colorValue);
+      });
     });
-    this.sizeInputs.forEach(input => {
-      input.addEventListener('change', () => this.updateVariant());
-    });
+
+
+    // Первый рендер страницы
+    const defaultColorInput = this.section.querySelector('input[name="color"]:checked');
+    if (defaultColorInput) {
+      this.updateMainImage(defaultColorInput.value);
+    }
+
+    this.updateVariant();
   }
 }
 
 document.addEventListener('DOMContentLoaded', () => {
   const section = document.querySelector('.product-detail');
-  if (section) {
-    new ProductDetail(section);
-  }
+  if (section) new ProductDetail(section);
 });

--- a/assets/global.js
+++ b/assets/global.js
@@ -1363,3 +1363,63 @@ class CartPerformance {
     );
   }
 }
+
+class ProductDetail {
+  constructor(section) {
+    this.section = section;
+
+    this.colorInputs = this.section.querySelectorAll('input[name="color"]');
+    this.sizeInputs = this.section.querySelectorAll('input[name="size"]');
+    this.availabilityEl = this.section.querySelector('#variant-availability');
+    this.addToCartBtn = this.section.querySelector('.product-detail__btn');
+
+    // парсим варианты
+    const variantsEl = document.getElementById('product-variants');
+    this.variants = variantsEl ? JSON.parse(variantsEl.textContent) : [];
+
+    this.init();
+  }
+
+  updateVariant() {
+    const selectedColor = this.section.querySelector('input[name="color"]:checked');
+    const selectedSize = this.section.querySelector('input[name="size"]:checked');
+
+    // Собираю массив выбранных опций
+    const selectedOptions = [];
+    if (selectedSize) selectedOptions.push(selectedSize.value);
+    if (selectedColor) selectedOptions.push(selectedColor.value);
+
+    // Ищу совпадения, заранее свел массивы к одному виду
+    const match = this.variants.find(v => {
+      const variantOptions = v.options.map(o => o.toLowerCase());
+      const selected = selectedOptions.map(o => o.toLowerCase());
+
+      return JSON.stringify(variantOptions) === JSON.stringify(selected);
+    });
+
+
+    if (match) {
+      if (match.available) {
+        this.availabilityEl.textContent = `In stock`;
+      } else {
+        this.availabilityEl.textContent = 'Sold out';
+      }
+    }
+  }
+
+  init() {
+    this.colorInputs.forEach(input => {
+      input.addEventListener('change', () => this.updateVariant());
+    });
+    this.sizeInputs.forEach(input => {
+      input.addEventListener('change', () => this.updateVariant());
+    });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const section = document.querySelector('.product-detail');
+  if (section) {
+    new ProductDetail(section);
+  }
+});

--- a/assets/global.js
+++ b/assets/global.js
@@ -1373,88 +1373,107 @@ class ProductDetail {
     this.addToCartBtn = this.section.querySelector('.product-detail__btn');
     this.mainImageEl = this.section.querySelector('.product-detail__wrapper-big-img img');
 
-    const productId = this.section.dataset.productId;
-
-    // парсинг JSON с вариантами и остатками
-    const inventoryDataEl = document.getElementById(`VariantInventory-${productId}`);
-    this.variants = inventoryDataEl ? JSON.parse(inventoryDataEl.textContent) : {};
+    const productId = section.dataset.productId;
+    this.variantsData = JSON.parse(document.querySelector(`#ProductVariants-${productId}`).textContent);
+    const translationsEl = document.querySelector('#Translations');
+    this.translations = translationsEl ? JSON.parse(translationsEl.textContent) : {};
 
     this.init();
   }
 
-  updateVariant() {
-    const selectedColor = this.section.querySelector('input[name="color"]:checked');
-    const selectedSize = this.section.querySelector('input[name="size"]:checked');
+  init() {
+    this.bindEvents();
+    this.renderDefaultState();
+    this.bindThumbnailClicks();
+  }
 
-    if (!selectedColor || !selectedSize) return;
-
-    // Сбор массива выбранных опций
-    const selectedOptions = [selectedSize.value, selectedColor.value].map(o => o.toLowerCase());
-
-    // Поиск вариантов у которых options совпадают с выбранными
-    const match = Object.values(this.variants).find(v => {
-      if (!v.options) return false;
-      const variantOptions = v.options.map(o => o.toLowerCase());
-      return selectedOptions.every(opt => variantOptions.includes(opt));
+  bindEvents() {
+    this.colorInputs.forEach(input => {
+      input.addEventListener('change', () => {
+        const color = input.value.toLowerCase();
+        this.toggleThumbnailGroups(color);
+        this.updateMainImage(color);
+        this.updateVariant();
+      });
     });
+    this.sizeInputs.forEach(input => {
+      input.addEventListener('change', () => this.updateVariant());
+    });
+  }
 
-    if (match) {
-      const quantity = match.inventory_quantity ?? 0;
-
-      if (match.available && quantity > 0) {
-        this.availabilityEl.textContent = `In stock: ${quantity}`;
-        this.addToCartBtn.disabled = false;
-      } else {
-        this.availabilityEl.textContent = 'Sold out';
-        this.addToCartBtn.disabled = true;
-      }
-    } else {
-      this.availabilityEl.textContent = 'Variant not found';
-      this.addToCartBtn.disabled = true;
+  renderDefaultState() {
+    const defaultColor = this.section.querySelector('input[name="color"]:checked');
+    if (defaultColor) {
+      const color = defaultColor.value.toLowerCase();
+      this.toggleThumbnailGroups(color);
+      this.updateMainImage(color);
     }
+    this.updateVariant();
+  }
+
+  updateVariant() {
+    const color = this.section.querySelector('input[name="color"]:checked')?.value;
+    const size = this.section.querySelector('input[name="size"]:checked')?.value;
+
+    const variantEl = Object.values(this.variantsData).find(v =>
+      v.option1?.toLowerCase() === color?.toLowerCase() &&
+      v.option2?.toLowerCase() === size?.toLowerCase()
+    );
+
+    if (!variantEl) return this.setSoldOut();
+
+    const quantity = Number(variantEl.inventory_quantity);
+    const available = Boolean(variantEl.available);
+    if (available && quantity > 0) {
+      this.setAvailable(quantity);
+    } else {
+      this.setSoldOut();
+    }
+  }
+
+  setAvailable(quantity) {
+    const textTemplate = this.translations.in_stock || 'In stock: ';
+    this.availabilityEl.textContent = `${textTemplate} ${quantity}`;
+    this.addToCartBtn.disabled = false;
+  }
+
+  setSoldOut() {
+    const soldOutText = this.translations.sold_out || 'Sold out';
+    this.availabilityEl.textContent = soldOutText;
+    this.addToCartBtn.disabled = true;
   }
 
   updateMainImage(colorValue) {
-    // Поиск цвета
-    const match = Object.values(this.variants).find(v => {
-      if (!v.options) return false;
-      return v.options.some(o => o.toLowerCase() === colorValue.toLowerCase());
-    });
+    const variantEl = this.section.querySelector(`input[name = "color"][value = "${colorValue}"]`);
+    if (!variantEl) return;
 
-    // Замена картинки
-      const imageUrl = match.featured_image.startsWith('//')
-        ? `https:${match.featured_image}`
-        : match.featured_image;
+    const imageUrl = variantEl.dataset.image;
 
-      if (this.mainImageEl) {
-        this.mainImageEl.src = imageUrl;
-        this.mainImageEl.srcset = ''; // сброс srcset
-        this.mainImageEl.alt = match.name || 'Product image';
-      }
-    }
+    this.mainImageEl.src = imageUrl.startsWith('//') ? `https:${imageUrl} ` : imageUrl;
+    this.mainImageEl.srcset = ''; // сброс srcset
   }
 
-  init() {
-    // Слушатели для радио кнопок, изменения состояний по клику
-    [...this.colorInputs, ...this.sizeInputs].forEach(input => {
-      input.addEventListener('change', () => this.updateVariant());
-    });
+  bindThumbnailClicks() {
+    const buttons = this.section.querySelectorAll('.product-detail__btn-img');
+    buttons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const large = btn.dataset.large;
+        if (large) this.mainImageEl.src = large;
 
-    this.colorInputs.forEach(input => {
-      input.addEventListener('change', (e) => {
-        const colorValue = e.target.value;
-        this.updateMainImage(colorValue);
+        btn.closest('.product-detail__thumb-group')
+          .querySelectorAll('.product-detail__btn-img')
+          .forEach(b => b.classList.remove('product-detail__btn-img--active'));
+
+        btn.classList.add('product-detail__btn-img--active');
       });
     });
+  }
 
-
-    // Первый рендер страницы
-    const defaultColorInput = this.section.querySelector('input[name="color"]:checked');
-    if (defaultColorInput) {
-      this.updateMainImage(defaultColorInput.value);
-    }
-
-    this.updateVariant();
+  toggleThumbnailGroups(color) {
+    const thumbGroups = this.section.querySelectorAll('.product-detail__thumb-group');
+    thumbGroups.forEach(group => {
+      group.style.display = group.dataset.color === color ? '' : 'none';
+    });
   }
 }
 

--- a/sections/custom-product-detail.liquid
+++ b/sections/custom-product-detail.liquid
@@ -2,31 +2,65 @@
 
 {% assign product = all_products[section.settings.product] %}
 
-{% if product %}
+<div class="page-width">
   <section class="product-detail" data-product-id="{{ product.id }}">
     <div class="product-detail__wrapper">
       <div class="product-detail__inner-left">
         <div class="product-detail__wrapper-big-img">
-          {% if product.featured_image %}
-            {{ product.featured_image | image_url: width: 600 | image_tag: alt: product.title }}
+          {% if product.featured_image != blank %}
+            {{ product.featured_image | image_url: width: 536 | image_tag: alt: product.title }}
           {% else %}
-            <div class="product-detail__placeholder">No image</div>
+            {{ 'image' | placeholder_svg_tag: 'product-detail__placeholder' }}
           {% endif %}
         </div>
+        {% if section.settings.show_thumbnails %}
+          <div class="product-detail__wrapper-btn-img" data-thumbs>
+            {% assign color_names = product.metafields.custom.color_product.value | map: 'name' %}
+            {% for color in color_names %}
+              {% assign variants_for_color = product.variants | where: 'option1', color %}
+              {% if variants_for_color.size == 0 %}
+                {% assign variants_for_color = product.variants | where: 'option2', color %}
+              {% endif %}
+              {% if variants_for_color.size > 0 %}
+                <div
+                  class="product-detail__thumb-group"
+                  data-color="{{ color | downcase }}"
+                  {% unless forloop.first %}
+                    style="display:none"
+                  {% endunless %}
+                >
+                  {% for variant in variants_for_color limit: 5 %}
+                    {% if variant.featured_image %}
+                      <button
+                        class="product-detail__btn-img {% if forloop.first %}product-detail__btn-img--active{% endif %}"
+                        type="button"
+                        data-large="{{ variant.featured_image | image_url: width: 800 }}"
+                      >
+                        {{ variant.featured_image | image_url: width: 88 | image_tag: alt: color }}
+                      </button>
+                    {% endif %}
+                  {% endfor %}
+                </div>
+              {% endif %}
+            {% endfor %}
+          </div>
+        {% endif %}
       </div>
       <div class="product-detail__inner-right">
-        <h2 class="product-detail__title">{{ product.title }}</h2>
+        <h2 class="product-detail__title">{{ product.title | default: 'Product title placeholder' }}</h2>
         <p class="product-detail__price">
           {% if product.compare_at_price > product.price %}
             <span class="product-detail__price--sale">{{ product.price | money }}</span>
-            <span class="product-detail__price--old">{{ product.compare_at_price | money }}</span>
+            <span class="product-detail__price--old">{{- product.compare_at_price | money -}}</span>
           {% else %}
-            <span>{{ product.price | money }}</span>
+            <span>{{ product.price | money | default: '$100.00' }}</span>
           {% endif %}
         </p>
+        <span class="product-detail__availability" id="variant-availability"> </span>
         {% assign product_colors = product.metafields.custom.color_product.value %}
         {% if product_colors %}
           <fieldset class="product-detail__option-color">
+            <legend class="product-detail__legend">{{ section.settings.color_text_title }}</legend>
             {% for color_entry in product_colors %}
               {% assign matched_variant = product.variants | where: 'option1', color_entry.name | first %}
               {% if matched_variant == null %}
@@ -52,12 +86,25 @@
               </label>
             {% endfor %}
           </fieldset>
+        {% else %}
+          <fieldset class="product-detail__option-color">
+            <legend class="product-detail__legend">{{ section.settings.color_text_title }}</legend>
+            {% assign placeholder_colors = 'Red,Green,Blue' | split: ',' %}
+            {% for color in placeholder_colors %}
+              <label class="custom-radio">
+                <input type="radio" name="color" disabled>
+                <span
+                  class="custom-radio__visual custom-radio__visual--color"
+                  style="background-color: {{ color | downcase }}"
+                ></span>
+              </label>
+            {% endfor %}
+          </fieldset>
         {% endif %}
-        <span class="product-detail__availability" id="variant-availability"> </span>
         {% assign product_sizes = product.metafields.custom.sizes.value %}
         {% if product_sizes %}
           <fieldset class="product-detail__option-size">
-            <legend class="product-detail__legend">Choose size:</legend>
+            <legend class="product-detail__legend">{{ section.settings.size_text_title }}</legend>
             <div class="product-detail__size-label-inner">
               {% for size in product_sizes %}
                 {% assign matched_variant = product.variants | where: 'option2', size.name | first %}
@@ -81,17 +128,35 @@
               {% endfor %}
             </div>
           </fieldset>
+        {% else %}
+          <fieldset class="product-detail__option-size">
+            <legend class="product-detail__legend">{{ section.settings.size_text_title }}</legend>
+            <div class="product-detail__size-label-inner">
+              {% assign placeholder_size = 'S,M,L' | split: ',' %}
+              {% for size in placeholder_size %}
+                <label class="custom-radio">
+                  <input type="radio" name="size" disabled>
+                  <span class="custom-radio__visual">{{ size }}</span>
+                </label>
+              {% endfor %}
+            </div>
+          </fieldset>
         {% endif %}
         <button class="product-detail__btn" type="submit">
           {{ 'products.product.add_to_cart' | t: default: 'Add to cart' }}
         </button>
         <p class="product-detail__description">
-          {{ product.description | strip_html | truncate: 200 }}
+          {{
+            product.description
+            | strip_html
+            | truncate: 200
+            | default: 'This is a sample placeholder description for your product section.'
+          }}
         </p>
       </div>
     </div>
   </section>
-{% endif %}
+</div>
 
 <script type="application/json" id="ProductVariants-{{ product.id }}">
   {
@@ -107,6 +172,12 @@
     {%- endfor -%}
   }
 </script>
+<script type="application/json" id="Translations">
+  {
+    "in_stock": {{ 'products.product.inventory_in_stock' | t: default: 'In stock: ' | json }},
+    "sold_out": {{ 'products.product.sold_out' | t: default: 'Sold out' | json }}
+  }
+</script>
 
 {% schema %}
 {
@@ -115,7 +186,25 @@
     {
       "type": "product",
       "id": "product",
-      "label": "Выберите продукт"
+      "label": "Select a product"
+    },
+    {
+      "type": "checkbox",
+      "id": "show_thumbnails",
+      "label": "Show product thumbnails",
+      "default": true
+    },
+    {
+      "type": "text",
+      "id": "color_text_title",
+      "label": "Color label text",
+      "default": "Choose color:"
+    },
+    {
+      "type": "text",
+      "id": "size_text_title",
+      "label": "Size label text",
+      "default": "Choose size:"
     }
   ],
   "presets": [

--- a/sections/custom-product-detail.liquid
+++ b/sections/custom-product-detail.liquid
@@ -1,0 +1,113 @@
+{% assign product = all_products[section.settings.product] %}
+{{ 'custom-product-detail.css' | asset_url | stylesheet_tag }}
+
+<script type="application/json" id="product-variants">
+  {{ product.variants | json }}
+</script>
+
+{% if product %}
+  <section class="product-detail">
+    <div class="container">
+      <div class="product-detail__wrapper">
+        <div class="product-detail__inner-left">
+          <div class="product-detail__wrapper-big-img">
+            {% if product.featured_image %}
+              {{ product.featured_image | image_url: width: 600 | image_tag: alt: product.title }}
+            {% else %}
+              <div class="product-detail__placeholder">No image</div>
+            {% endif %}
+          </div>
+        </div>
+        <div class="product-detail__inner-right">
+          <h2 class="product-detail__title">{{ product.title }}</h2>
+          <p class="product-detail__price">
+            {% if product.compare_at_price > product.price %}
+              <span class="product-detail__price--sale">{{ product.price | money }}</span>
+              <span class="product-detail__price--old">{{ product.compare_at_price | money }}</span>
+            {% else %}
+              <span>{{ product.price | money }}</span>
+            {% endif %}
+          </p>
+          {% for option in product.options %}
+            {% assign option_color = option | downcase %}
+            {% if option_color == 'color' %}
+              {% assign color_index = forloop.index0 %}
+            {% endif %}
+          {% endfor %}
+          {% if color_index != blank %}
+            <fieldset class="product-detail__option-color">
+              {% for variant in product.variants limit: 3 %}
+                {% assign color_name = variant.options[color_index] | downcase | replace: ' ', '-' %}
+                <label class="custom-radio">
+                  <input
+                    type="radio"
+                    name="color"
+                    value="{{ color_name }}"
+                    {% if forloop.first %}
+                      checked
+                    {% endif %}
+                  >
+                  <span class="custom-radio__visual custom-radio__visual--color color-{{ color_name }}"></span>
+                </label>
+              {% endfor %}
+            </fieldset>
+          {% endif %}
+          <span class="product-detail__availability" id="variant-availability"> </span>
+          {%- assign size_index = blank -%}
+          {%- for option in product.options -%}
+            {% assign option_size = option | downcase %}
+            {% if option_size == 'size' %}
+              {% assign size_index = forloop.index0 %}
+            {% endif %}
+          {%- endfor -%}
+          {% if size_index != blank %}
+            <fieldset class="product-detail__option-size">
+              <legend class="product-detail__legend">Choose size:</legend>
+              <div class="product-detail__size-label-inner">
+                {%- assign sizes = '' -%}
+                {%- for variant in product.variants -%}
+                  {% assign size_value = variant.options[size_index] %}
+                  {% unless sizes contains size_value %}
+                    <label class="custom-radio">
+                      <input
+                        type="radio"
+                        name="size"
+                        value="{{ size_value }}"
+                      >
+                      <span class="custom-radio__visual">{{ size_value }}</span>
+                    </label>
+                    {% assign sizes = sizes | append: size_value | append: ',' %}
+                  {% endunless %}
+                {%- endfor -%}
+              </div>
+            </fieldset>
+          {% endif %}
+          <button class="product-detail__btn" type="submit">
+            {{ 'products.product.add_to_cart' | t: default: 'Add to cart' }}
+          </button>
+          <p class="product-detail__description">
+            {{ product.description | strip_html | truncate: 200 }}
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endif %}
+
+{% schema %}
+{
+  "name": "Product Detail",
+  "settings": [
+    {
+      "type": "product",
+      "id": "product",
+      "label": "Выберите продукт"
+    }
+  ],
+  "presets": [
+    {
+      "name": "Product Detail"
+    }
+  ]
+}
+{% endschema %}

--- a/sections/custom-product-detail.liquid
+++ b/sections/custom-product-detail.liquid
@@ -1,98 +1,110 @@
 {% assign product = all_products[section.settings.product] %}
 {{ 'custom-product-detail.css' | asset_url | stylesheet_tag }}
 
-<script type="application/json" id="product-variants">
-  {{ product.variants | json }}
-</script>
-
 {% if product %}
-  <section class="product-detail">
-    <div class="container">
-      <div class="product-detail__wrapper">
-        <div class="product-detail__inner-left">
-          <div class="product-detail__wrapper-big-img">
-            {% if product.featured_image %}
-              {{ product.featured_image | image_url: width: 600 | image_tag: alt: product.title }}
-            {% else %}
-              <div class="product-detail__placeholder">No image</div>
-            {% endif %}
-          </div>
-        </div>
-        <div class="product-detail__inner-right">
-          <h2 class="product-detail__title">{{ product.title }}</h2>
-          <p class="product-detail__price">
-            {% if product.compare_at_price > product.price %}
-              <span class="product-detail__price--sale">{{ product.price | money }}</span>
-              <span class="product-detail__price--old">{{ product.compare_at_price | money }}</span>
-            {% else %}
-              <span>{{ product.price | money }}</span>
-            {% endif %}
-          </p>
-          {% for option in product.options %}
-            {% assign option_color = option | downcase %}
-            {% if option_color == 'color' %}
-              {% assign color_index = forloop.index0 %}
-            {% endif %}
-          {% endfor %}
-          {% if color_index != blank %}
-            <fieldset class="product-detail__option-color">
-              {% for variant in product.variants limit: 3 %}
-                {% assign color_name = variant.options[color_index] | downcase | replace: ' ', '-' %}
-                <label class="custom-radio">
-                  <input
-                    type="radio"
-                    name="color"
-                    value="{{ color_name }}"
-                    {% if forloop.first %}
-                      checked
-                    {% endif %}
-                  >
-                  <span class="custom-radio__visual custom-radio__visual--color color-{{ color_name }}"></span>
-                </label>
-              {% endfor %}
-            </fieldset>
+  <section class="product-detail" data-product-id="{{ product.id }}">
+    <div class="product-detail__wrapper">
+      <div class="product-detail__inner-left">
+        <div class="product-detail__wrapper-big-img">
+          {% if product.featured_image %}
+            {{ product.featured_image | image_url: width: 600 | image_tag: alt: product.title }}
+          {% else %}
+            <div class="product-detail__placeholder">No image</div>
           {% endif %}
-          <span class="product-detail__availability" id="variant-availability"> </span>
-          {%- assign size_index = blank -%}
-          {%- for option in product.options -%}
-            {% assign option_size = option | downcase %}
-            {% if option_size == 'size' %}
-              {% assign size_index = forloop.index0 %}
-            {% endif %}
-          {%- endfor -%}
-          {% if size_index != blank %}
-            <fieldset class="product-detail__option-size">
-              <legend class="product-detail__legend">Choose size:</legend>
-              <div class="product-detail__size-label-inner">
-                {%- assign sizes = '' -%}
-                {%- for variant in product.variants -%}
-                  {% assign size_value = variant.options[size_index] %}
-                  {% unless sizes contains size_value %}
+        </div>
+      </div>
+      <div class="product-detail__inner-right">
+        <h2 class="product-detail__title">{{ product.title }}</h2>
+        <p class="product-detail__price">
+          {% if product.compare_at_price > product.price %}
+            <span class="product-detail__price--sale">{{ product.price | money }}</span>
+            <span class="product-detail__price--old">{{ product.compare_at_price | money }}</span>
+          {% else %}
+            <span>{{ product.price | money }}</span>
+          {% endif %}
+        </p>
+
+        {% assign product_colors = product.metafields.custom.color_product.value %}
+
+        {% if product_colors %}
+          <fieldset class="product-detail__option-color">
+            {% for color_entry in product_colors %}
+              <label class="custom-radio">
+                <input
+                  class="custom-radio__field"
+                  type="radio"
+                  name="color"
+                  value="{{ color_entry.name | downcase | strip }}"
+                  {% if forloop.first %}
+                    checked
+                  {% endif %}
+                >
+                <span
+                  class="custom-radio__visual custom-radio__visual--color"
+                  style="background-color: {{ color_entry.color }};"
+                ></span>
+              </label>
+            {% endfor %}
+          </fieldset>
+        {% endif %}
+        <span class="product-detail__availability" id="variant-availability"> </span>
+        {%- assign size_index = blank -%}
+        {%- for option in product.options -%}
+          {% assign option_size = option | downcase %}
+          {% if option_size == 'size' %}
+            {% assign size_index = forloop.index0 %}
+          {% endif %}
+        {%- endfor -%}
+        {% if size_index != blank %}
+          <fieldset class="product-detail__option-size">
+            <legend class="product-detail__legend">Choose size:</legend>
+            <div class="product-detail__size-label-inner">
+              {% assign product_sizes = product.metafields.custom.sizes.value %}
+              {% if product_sizes %}
+                {% for size in product_sizes %}
+                  {% if size.category == 'Shoes' %}
                     <label class="custom-radio">
                       <input
+                        class="custom-radio__field"
                         type="radio"
                         name="size"
-                        value="{{ size_value }}"
+                        value="{{ size.name }}"
+                        {% if forloop.first %}
+                          checked
+                        {% endif %}
                       >
-                      <span class="custom-radio__visual">{{ size_value }}</span>
+                      <span class="custom-radio__visual">{{ size.name }}</span>
                     </label>
-                    {% assign sizes = sizes | append: size_value | append: ',' %}
-                  {% endunless %}
-                {%- endfor -%}
-              </div>
-            </fieldset>
-          {% endif %}
-          <button class="product-detail__btn" type="submit">
-            {{ 'products.product.add_to_cart' | t: default: 'Add to cart' }}
-          </button>
-          <p class="product-detail__description">
-            {{ product.description | strip_html | truncate: 200 }}
-          </p>
-        </div>
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            </div>
+          </fieldset>
+        {% endif %}
+        <button class="product-detail__btn" type="submit">
+          {{ 'products.product.add_to_cart' | t: default: 'Add to cart' }}
+        </button>
+        <p class="product-detail__description">
+          {{ product.description | strip_html | truncate: 200 }}
+        </p>
       </div>
     </div>
   </section>
 {% endif %}
+
+<script type="application/json" id="VariantInventory-{{ product.id }}">
+  {
+    {%- for v in product.variants -%}
+      "{{ v.id }}": {
+        "title": {{ v.title | json }},
+        "options": {{ v.options | json }},
+        "available": {{ v.available | json }},
+        "inventory_quantity": {{ v.inventory_quantity | default: 0 | json }},
+        "featured_image": {{ v.featured_image | json }}
+      }{% unless forloop.last %},{% endunless %}
+    {%- endfor -%}
+  }
+</script>
 
 {% schema %}
 {

--- a/sections/custom-product-detail.liquid
+++ b/sections/custom-product-detail.liquid
@@ -1,5 +1,6 @@
-{% assign product = all_products[section.settings.product] %}
 {{ 'custom-product-detail.css' | asset_url | stylesheet_tag }}
+
+{% assign product = all_products[section.settings.product] %}
 
 {% if product %}
   <section class="product-detail" data-product-id="{{ product.id }}">
@@ -23,18 +24,23 @@
             <span>{{ product.price | money }}</span>
           {% endif %}
         </p>
-
         {% assign product_colors = product.metafields.custom.color_product.value %}
-
         {% if product_colors %}
           <fieldset class="product-detail__option-color">
             {% for color_entry in product_colors %}
+              {% assign matched_variant = product.variants | where: 'option1', color_entry.name | first %}
+              {% if matched_variant == null %}
+                {% assign matched_variant = product.variants | where: 'option2', color_entry.name | first %}
+              {% endif %}
               <label class="custom-radio">
                 <input
                   class="custom-radio__field"
                   type="radio"
                   name="color"
-                  value="{{ color_entry.name | downcase | strip }}"
+                  value="{{ color_entry.name | downcase }}"
+                  data-image="{{ matched_variant.featured_image | image_url: width: 600 }}"
+                  data-stock="{{ matched_variant.inventory_quantity }}"
+                  data-available="{{ matched_variant.available }}"
                   {% if forloop.first %}
                     checked
                   {% endif %}
@@ -48,36 +54,31 @@
           </fieldset>
         {% endif %}
         <span class="product-detail__availability" id="variant-availability"> </span>
-        {%- assign size_index = blank -%}
-        {%- for option in product.options -%}
-          {% assign option_size = option | downcase %}
-          {% if option_size == 'size' %}
-            {% assign size_index = forloop.index0 %}
-          {% endif %}
-        {%- endfor -%}
-        {% if size_index != blank %}
+        {% assign product_sizes = product.metafields.custom.sizes.value %}
+        {% if product_sizes %}
           <fieldset class="product-detail__option-size">
             <legend class="product-detail__legend">Choose size:</legend>
             <div class="product-detail__size-label-inner">
-              {% assign product_sizes = product.metafields.custom.sizes.value %}
-              {% if product_sizes %}
-                {% for size in product_sizes %}
-                  {% if size.category == 'Shoes' %}
-                    <label class="custom-radio">
-                      <input
-                        class="custom-radio__field"
-                        type="radio"
-                        name="size"
-                        value="{{ size.name }}"
-                        {% if forloop.first %}
-                          checked
-                        {% endif %}
-                      >
-                      <span class="custom-radio__visual">{{ size.name }}</span>
-                    </label>
-                  {% endif %}
-                {% endfor %}
-              {% endif %}
+              {% for size in product_sizes %}
+                {% assign matched_variant = product.variants | where: 'option2', size.name | first %}
+                {% if matched_variant == null %}
+                  {% assign matched_variant = product.variants | where: 'option1', size.name | first %}
+                {% endif %}
+                <label class="custom-radio">
+                  <input
+                    class="custom-radio__field"
+                    type="radio"
+                    name="size"
+                    value="{{ size.name }}"
+                    data-stock="{{ matched_variant.inventory_quantity }}"
+                    data-available="{{ matched_variant.available }}"
+                    {% if forloop.first %}
+                      checked
+                    {% endif %}
+                  >
+                  <span class="custom-radio__visual">{{ size.name }}</span>
+                </label>
+              {% endfor %}
             </div>
           </fieldset>
         {% endif %}
@@ -92,15 +93,16 @@
   </section>
 {% endif %}
 
-<script type="application/json" id="VariantInventory-{{ product.id }}">
+<script type="application/json" id="ProductVariants-{{ product.id }}">
   {
     {%- for v in product.variants -%}
       "{{ v.id }}": {
-        "title": {{ v.title | json }},
-        "options": {{ v.options | json }},
+        "id": {{ v.id | json }},
         "available": {{ v.available | json }},
         "inventory_quantity": {{ v.inventory_quantity | default: 0 | json }},
-        "featured_image": {{ v.featured_image | json }}
+        "option1": {{ v.option1 | json }},
+        "option2": {{ v.option2 | json }},
+        "featured_image": {{ v.featured_image | image_url: width: 800 | json }}
       }{% unless forloop.last %},{% endunless %}
     {%- endfor -%}
   }


### PR DESCRIPTION
**Опис завдання:**
Реалізувати універсальний банер продукту, який можна вставляти на будь-яку сторінку. В банері відображаються основні дані продукту: фото, назва, ціна, кольори та розміри, а також інформація про наявність.

**Реалізований функціонал:**
•	Створено кастомну секцію custom-product-detail
•	Вивід заголовку, ціни та опису продукту
•	Вивід головного зображення продукту
•	Рендер кольорів (радіо-кнопки)
•	Рендер розмірів (радіо-кнопки)
•	Логіка вибору комбінації color + size через JS
•	Вивід інформації про доступність варіанта (In stock / Sold out)
•	Кнопка “Add to Cart” з локалями
•	Додані стилі для кольорів та розмірів (custom radio inputs)

**Технології та підходи**
•	Liquid (Shopify) для рендерингу даних продукту
•	JavaScript (класова структура в global.js) для логіки вибору варіантів
•	SCSS/CSS для стилізації custom radio
•	Локалі Shopify для кнопки Add to Cart та повідомлень

**Примітки**
•	Через обмеження часу (робота + не дуже добре самопочуття) реалізовано тільки основний функціонал, але обов'язково дороблю
•	Логіку підрахунку кількості (inventory_quantity) довелось тимчасово зробити через JS-оновлення тексту, бо у варіантах в JSON не відображались залишки.
•	Частина стилів зроблена тимчасово, пізніше планую переробити.

**Пов’язані ресурси**
•	https://shopify.dev/docs/api/liquid/objects/product
•	https://shopify.dev/docs/api/liquid/objects/variant